### PR TITLE
Update DomainSnapshot.java

### DIFF
--- a/src/main/java/org/libvirt/DomainSnapshot.java
+++ b/src/main/java/org/libvirt/DomainSnapshot.java
@@ -35,13 +35,7 @@ public class DomainSnapshot {
      * @throws LibvirtException
      */
     public int delete(int flags) throws LibvirtException {
-        int success = 0;
-        if (VDSP != null) {
-            success = processError(libvirt.virDomainSnapshotDelete(VDSP, flags));
-            VDSP = null;
-        }
-
-        return success;
+        return processError(libvirt.virDomainSnapshotDelete(VDSP, flags));
     }
 
     @Override


### PR DESCRIPTION
fix bug: if set VDSP to null during method delete(), it can't be freed in method free()